### PR TITLE
Fix EEPROM bank offset

### DIFF
--- a/SoilSensor.h
+++ b/SoilSensor.h
@@ -33,8 +33,8 @@ MIT License
 
 #define EEPROM_ADDRESS    0x51
 #define EEPROM_BANK_A     0
-#define EEPROM_BANK_B     170
-#define EEPROM_BANK_C     340
+#define EEPROM_BANK_B     0x080
+#define EEPROM_BANK_C     0x100
 
 #define BC_SOIL_SENSOR_SIGNATURE 0xdeadbeef
 #define BC_SOIL_SENSOR_MIN 1700


### PR DESCRIPTION
Before EEPROM magic header returns bad value `EEPROM header: 5CFACFE 20 46 9405` instead "deadbeef" one.. This fixed this one.

`EEPROM header: DEADBEEF 1 42 62424`